### PR TITLE
Add about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>About</title>
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/locomotive-scroll@4.1.4/dist/locomotive-scroll.min.css" />
+</head>
+<body class="dark">
+  <main data-scroll-container>
+    <section data-scroll-section>
+      <nav class="navbar">
+        <a href="index.html" class="nav-item nav-left">vicente venegas*</a>
+        <a href="index.html#about" class="nav-item nav-about">about↗</a>
+        <a href="index.html#contact" class="nav-item nav-contact">contact↗</a>
+      </nav>
+    </section>
+
+    <section class="about" data-scroll-section>
+      <div class="about-container">
+        <p class="about-summary">Soy un diseñador con enfoque en UX/UI y diseño de servicios, con experiencia en investigación de usuarios, accesibilidad y prototipado. He trabajado en equipos interdisciplinarios, aplicando metodologías de diseño centradas en el usuario y análisis de datos para la toma de decisiones.</p>
+
+        <div class="about-experience">
+          <h2>Experience</h2>
+          <div class="about-entry">
+            <p>Design Intern — Public Sector<br>National Disability Service (SENADIS)</p>
+            <p class="about-date">Marzo 2016 — Julio 2017</p>
+          </div>
+          <div class="about-entry">
+            <p>Design Intern – Brand Strategy<br>Almabrands</p>
+            <p class="about-date">Marzo 2016 — Julio 2017</p>
+          </div>
+          <div class="about-entry">
+            <p>Finalist<br>OpenBeauchef, IBM Innovation Tournament</p>
+            <p class="about-date">Marzo 2016 — Julio 2017</p>
+          </div>
+          <div class="about-entry">
+            <p>Teaching Assistant<br>Pontificia Universidad Católica</p>
+            <p class="about-date">Marzo 2016 — Julio 2017</p>
+          </div>
+        </div>
+
+        <div class="about-education">
+          <h2>Education</h2>
+          <div class="about-entry">
+            <p>Bachelor’s Degree in Design — Pontificia Universidad Católica</p>
+            <p class="about-date">Marzo 2016 — Julio 2017</p>
+          </div>
+          <div class="about-entry">
+            <p>Engineering Coursework (CS) — Universidad de Chile</p>
+            <p class="about-date">Marzo 2016 — Julio 2017</p>
+          </div>
+          <div class="about-entry">
+            <p>AI Alignment Course – AI Safety Fundamentals</p>
+            <p class="about-date">September 2023 – January 2024</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/locomotive-scroll@4.1.4/dist/locomotive-scroll.min.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -877,3 +877,71 @@ body.dark {
     grid-column: 1 / span 4;
   }
 }
+
+/* === ABOUT PAGE === */
+.about-container {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--gutter);
+  padding: 2rem var(--margin);
+}
+
+.about-summary {
+  grid-column: 1 / span 2;
+  font-size: 1rem;
+  line-height: 1.4;
+  margin-bottom: 2rem;
+}
+
+.about-experience {
+  grid-column: 1 / span 2;
+}
+
+.about-education {
+  grid-column: 3 / span 2;
+}
+
+.about-experience h2,
+.about-education h2 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.about-entry {
+  margin-bottom: 1rem;
+}
+
+.about-date {
+  color: gray;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+@media (max-width: 768px) {
+  .about-container {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .about-summary {
+    grid-column: 1 / span 2;
+  }
+  .about-experience {
+    grid-column: 1 / span 2;
+  }
+  .about-education {
+    grid-column: 1 / span 2;
+  }
+}
+
+@media (max-width: 480px) {
+  .about-container {
+    grid-template-columns: 1fr;
+  }
+  .about-summary {
+    grid-column: 1 / span 1;
+  }
+  .about-experience,
+  .about-education {
+    grid-column: 1 / span 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add new `about.html` page with black background and white text
- include experience and education sections
- style about page layout in `styles.css`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688833c47e108320ab222c09aed2cdc7