### PR TITLE
Adjust contact footer layout

### DIFF
--- a/css/footer.css
+++ b/css/footer.css
@@ -64,15 +64,10 @@ body.dark {
 }
 
 .contact-page .contact-block .talk-footer,
-.contact-page .contact-block .hand-footer,
 .contact-page .contact-block .footer-contact-text {
   position: static;
   top: auto;
   left: auto;
-}
-
-.contact-page .contact-block .hand-footer {
-  align-self: flex-end;
 }
 
 

--- a/script.js
+++ b/script.js
@@ -21,6 +21,9 @@ window.addEventListener('DOMContentLoaded', () => {
   const cursor              = document.getElementById('custom-cursor');
   const heroSVGs            = document.querySelectorAll('.hero .svg-container');
   const footerDownArrow     = document.getElementById('footer-down');
+  const talkFooter          = document.querySelector('.contact-block .talk-footer');
+  const contactText         = document.querySelector('.contact-block .footer-contact-text');
+  const handFooter          = document.querySelector('.contact-block .hand-footer');
 
   const SNAP_SETTINGS = {
     duration: 500,
@@ -28,6 +31,19 @@ window.addEventListener('DOMContentLoaded', () => {
   };
 
   let isManuallyScrollingToFooter = false;
+
+  function layoutContact() {
+    if (!talkFooter || !contactText || !handFooter) return;
+    const width = contactText.offsetWidth;
+    talkFooter.style.width = `${width}px`;
+    const height = contactText.offsetHeight;
+    handFooter.style.position = 'absolute';
+    handFooter.style.left = `${width}px`;
+    handFooter.style.top = `${height}px`;
+  }
+
+  layoutContact();
+  window.addEventListener('resize', layoutContact);
 
   // Scroll helpers
   function scrollToProjects(e) {


### PR DESCRIPTION
## Summary
- match "Let's talk" width to the contact text
- reposition the waving hand graphic under the contact text
- compute layout dynamically on resize

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688aad1e3c248320aef7da8b80293be6