### PR TITLE
Improve mobile menu and contact layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,9 +12,15 @@
     <section data-scroll-section>
       <nav class="navbar">
         <a href="index.html" class="nav-item nav-left">vicente venegas*</a>
-        <a href="about.html" class="nav-item nav-about">about↗</a>
-        <a href="contact.html" class="nav-item nav-contact">contact↗</a>
+        <button id="menu-toggle" class="nav-item nav-menu" aria-label="menu">
+          <img src="svg/menu2.svg" alt="Menu">
+        </button>
       </nav>
+      <div id="menu-overlay" class="menu-overlay">
+        <a href="index.html">home↗</a>
+        <a href="about.html">about↗</a>
+        <a href="contact.html">contact↗</a>
+      </div>
     </section>
 
     <section class="about" data-scroll-section>

--- a/contact.html
+++ b/contact.html
@@ -12,9 +12,15 @@
     <section data-scroll-section>
       <nav class="navbar">
         <a href="index.html" class="nav-item nav-left">vicente venegas*</a>
-        <a href="about.html" class="nav-item nav-about">about↗</a>
-        <a href="contact.html" class="nav-item nav-contact">contact↗</a>
+        <button id="menu-toggle" class="nav-item nav-menu" aria-label="menu">
+          <img src="svg/menu2.svg" alt="Menu">
+        </button>
       </nav>
+      <div id="menu-overlay" class="menu-overlay">
+        <a href="index.html">home↗</a>
+        <a href="about.html">about↗</a>
+        <a href="contact.html">contact↗</a>
+      </div>
     </section>
 
     <footer id="contact" class="footer" data-scroll-section>

--- a/css/footer.css
+++ b/css/footer.css
@@ -96,7 +96,7 @@ body.dark {
 /* Social icons */
 .footer-social {
   position: absolute;
-  bottom: 4%;
+  bottom: var(--margin);
   right: var(--margin);
   display: flex;
   gap: var(--gutter);
@@ -125,6 +125,12 @@ body.dark {
 }
 .contact-page .footer {
   height: calc(100vh - var(--navbar-height));
+}
+
+@supports (height: 100dvh) {
+  .contact-page .footer {
+    height: calc(100dvh - var(--navbar-height));
+  }
 }
 
 /* Adjust footer height for different aspect ratios */
@@ -161,7 +167,7 @@ body.dark {
 
   /* Make social icons smaller on mobile */
   .footer-social img {
-    width: clamp(2rem, 2.5vw, 2.75rem); /* Smaller size for mobile */
+    width: clamp(2.5rem, 3vw, 3rem); /* Slightly larger size for mobile */
     height: auto;
   }
 

--- a/css/nav.css
+++ b/css/nav.css
@@ -24,20 +24,26 @@
   color: inherit;
 }
 
+.nav-menu {
+  grid-column: 6;
+  justify-self: end;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.nav-menu img {
+  width: clamp(1.5rem, 2vw + 0.5rem, 2rem);
+  height: auto;
+}
+
 .nav-left {
   grid-column: 1 / span 2;
   justify-self: start;
 }
 
-.nav-about {
-  grid-column: 5;
-  justify-self: end;
-}
 
-.nav-contact {
-  grid-column: 6;
-  justify-self: end;
-}
 
 @media (max-width: 768px) {
   .navbar {
@@ -47,17 +53,11 @@
   }
 
   .nav-left {
-    grid-column: 1 / span 2;
+    grid-column: 1 / span 3;
   }
 
-  .nav-about {
-    grid-column: 3;
-    justify-self: end;
-  }
-
-  .nav-contact {
+  .nav-menu {
     grid-column: 4;
-    justify-self: end;
   }
 }
 
@@ -69,22 +69,20 @@
   }
 
   .nav-left {
-    grid-column: 1 / span 2;
+    grid-column: 1 / span 3;
     justify-self: start;
   }
 
-  .nav-about {
-    grid-column: 3;
-    justify-self: end;
-  }
-
-  .nav-contact {
+  .nav-menu {
     grid-column: 4;
-    justify-self: end;
   }
 
   .nav-item {
     font-size: 1rem;
+  }
+
+  .nav-menu img {
+    width: clamp(2rem, 5vw, 2.5rem);
   }
 }
 
@@ -103,4 +101,31 @@
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+/* === MENU OVERLAY === */
+.menu-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.95);
+  color: #fff;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  z-index: 999;
+}
+
+.menu-overlay a {
+  font-size: 1.5rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.menu-overlay.open {
+  display: flex;
 }

--- a/index.html
+++ b/index.html
@@ -15,10 +15,16 @@
       <nav class="navbar">
         <!-- Using <a> tags for better semantics and tab navigation -->
         <a href="#" class="nav-item nav-left" id="scroll-to-projects">vicente venegas*</a>
-        <a href="about.html" class="nav-item nav-about">about↗</a>
-        <a href="#" id="scroll-to-footer" class="nav-item nav-contact">contact↗</a>
+        <button id="menu-toggle" class="nav-item nav-menu" aria-label="menu">
+          <img src="svg/menu.svg" alt="Menu">
+        </button>
 
       </nav>
+      <div id="menu-overlay" class="menu-overlay">
+        <a href="index.html">home↗</a>
+        <a href="about.html">about↗</a>
+        <a href="contact.html">contact↗</a>
+      </div>
     </section>
 
     <!-- Hero Section -->

--- a/project_djavu.html
+++ b/project_djavu.html
@@ -15,9 +15,15 @@
       <nav class="navbar">
         <!-- Using <a> tags for better semantics and tab navigation -->
         <a href="index.html" class="nav-item nav-left">vicente venegas*</a>
-        <a href="about.html" class="nav-item nav-about">about↗</a>
-        <a href="contact.html" class="nav-item nav-contact">contact↗</a>
+        <button id="menu-toggle" class="nav-item nav-menu" aria-label="menu">
+          <img src="svg/menu.svg" alt="Menu">
+        </button>
      </nav>
+      <div id="menu-overlay" class="menu-overlay">
+        <a href="index.html">home↗</a>
+        <a href="about.html">about↗</a>
+        <a href="contact.html">contact↗</a>
+      </div>
     </section>
 
     <!-- Project Details Section -->

--- a/script.js
+++ b/script.js
@@ -24,6 +24,15 @@ window.addEventListener('DOMContentLoaded', () => {
   const talkFooter          = document.querySelector('.contact-block .talk-footer');
   const contactText         = document.querySelector('.contact-block .footer-contact-text');
   const handFooter          = document.querySelector('.contact-block .hand-footer');
+  const menuToggle          = document.getElementById('menu-toggle');
+  const menuOverlay         = document.getElementById('menu-overlay');
+
+  function updateMenuIcon() {
+    if (!menuToggle) return;
+    const img = menuToggle.querySelector('img');
+    if (!img) return;
+    img.src = document.body.classList.contains('dark') ? 'svg/menu2.svg' : 'svg/menu.svg';
+  }
 
   const SNAP_SETTINGS = {
     duration: 500,
@@ -44,6 +53,17 @@ window.addEventListener('DOMContentLoaded', () => {
 
   layoutContact();
   window.addEventListener('resize', layoutContact);
+
+  // Menu overlay toggle
+  menuToggle?.addEventListener('click', () => {
+    menuOverlay?.classList.toggle('open');
+  });
+
+  menuOverlay?.querySelectorAll('a').forEach(link =>
+    link.addEventListener('click', () => menuOverlay.classList.remove('open'))
+  );
+
+  updateMenuIcon();
 
   // Scroll helpers
   function scrollToProjects(e) {
@@ -128,6 +148,7 @@ window.addEventListener('DOMContentLoaded', () => {
     if (footer) {
       const bottom = y + vh;
       document.body.classList.toggle('dark', bottom >= fY + fH * 0.4);
+      updateMenuIcon();
     }
 
     // Fade in footer arrow

--- a/svg/menu.svg
+++ b/svg/menu.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 100 80" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="10" rx="5" fill="black"/>
+  <rect y="35" width="100" height="10" rx="5" fill="black"/>
+  <rect y="70" width="100" height="10" rx="5" fill="black"/>
+</svg>

--- a/svg/menu2.svg
+++ b/svg/menu2.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 100 80" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="10" rx="5" fill="white"/>
+  <rect y="35" width="100" height="10" rx="5" fill="white"/>
+  <rect y="70" width="100" height="10" rx="5" fill="white"/>
+</svg>


### PR DESCRIPTION
## Summary
- add hamburger icons
- create overlay menu and remove about/contact nav items
- adjust footer social icon size and spacing
- improve contact footer height using `100dvh`
- update script to toggle menu overlay and swap icon for dark backgrounds

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ab3406ec48320ba7970ead11d74f8