### PR TITLE
Fix mobile menu overlay and contact layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,14 +15,16 @@
         <a href="about.html" class="nav-item nav-about">about↗</a>
         <a href="contact.html" class="nav-item nav-contact">contact↗</a>
         <a href="#" class="nav-item nav-menu" id="open-menu">
-          <img src="svg/menu2.svg" class="menu-dark" alt="Menu">
-          <img src="svg/menu.svg.svg" class="menu-light" alt="Menu">
+          <img src="svg/menu2.svg" class="menu-dark menu-icon" alt="Menu">
+          <img src="svg/menu.svg.svg" class="menu-light menu-icon" alt="Menu">
+          <img src="svg/close.svg" class="close-dark menu-icon" alt="Close">
+          <img src="svg/close2.svg" class="close-light menu-icon" alt="Close">
         </a>
       </nav>
       <div id="mobile-menu" class="mobile-menu-overlay">
-        <a href="index.html">home</a>
-        <a href="about.html">about</a>
-        <a href="contact.html">contact</a>
+        <a href="index.html">home↗</a>
+        <a href="about.html">about↗</a>
+        <a href="contact.html">contact↗</a>
       </div>
     </section>
 

--- a/contact.html
+++ b/contact.html
@@ -15,14 +15,16 @@
         <a href="about.html" class="nav-item nav-about">about↗</a>
         <a href="contact.html" class="nav-item nav-contact">contact↗</a>
         <a href="#" class="nav-item nav-menu" id="open-menu">
-          <img src="svg/menu2.svg" class="menu-dark" alt="Menu">
-          <img src="svg/menu.svg.svg" class="menu-light" alt="Menu">
+          <img src="svg/menu2.svg" class="menu-dark menu-icon" alt="Menu">
+          <img src="svg/menu.svg.svg" class="menu-light menu-icon" alt="Menu">
+          <img src="svg/close.svg" class="close-dark menu-icon" alt="Close">
+          <img src="svg/close2.svg" class="close-light menu-icon" alt="Close">
         </a>
       </nav>
       <div id="mobile-menu" class="mobile-menu-overlay">
-        <a href="index.html">home</a>
-        <a href="about.html">about</a>
-        <a href="contact.html">contact</a>
+        <a href="index.html">home↗</a>
+        <a href="about.html">about↗</a>
+        <a href="contact.html">contact↗</a>
       </div>
     </section>
 

--- a/css/footer.css
+++ b/css/footer.css
@@ -175,3 +175,14 @@ body.dark {
     --contact-top: 30%;
   }
 }
+
+/* Ensure contact page footer always fills the screen */
+.contact-page .footer {
+  height: calc(100svh - var(--navbar-height));
+}
+
+@media (max-width: 850px), (orientation: landscape) and (max-height: 500px) {
+  .footer .svg-container.hand-footer {
+    display: none;
+  }
+}

--- a/css/nav.css
+++ b/css/nav.css
@@ -50,14 +50,29 @@
   height: auto;
 }
 
-.menu-light {
+/* default icon visibility */
+.menu-light,
+.close-light {
   display: none;
 }
-body.dark .menu-light {
+.close-dark {
+  display: none;
+}
+body.dark .menu-light,
+body.dark .close-light {
   display: block;
 }
-body.dark .menu-dark {
+body.dark .menu-dark,
+body.dark .close-dark {
   display: none;
+}
+.nav-menu.open .menu-dark,
+.nav-menu.open .menu-light {
+  display: none;
+}
+.nav-menu.open .close-dark,
+.nav-menu.open .close-light {
+  display: block;
 }
 
 @media (max-width: 768px) {
@@ -131,7 +146,7 @@ body.dark .menu-dark {
 .mobile-menu-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.95);
+  background: #ffffff;
   display: none;
   flex-direction: column;
   justify-content: flex-end;
@@ -139,16 +154,22 @@ body.dark .menu-dark {
   padding: var(--margin);
   z-index: 999;
 }
+body.dark .mobile-menu-overlay {
+  background: #000000;
+}
 
 .mobile-menu-overlay.open {
   display: flex;
 }
 
 .mobile-menu-overlay a {
-  color: #ffffff;
+  color: #000000;
   text-decoration: none;
   font-size: 2rem;
   margin-top: 1rem;
+}
+body.dark .mobile-menu-overlay a {
+  color: #ffffff;
 }
 
 @media (min-width: 481px) {

--- a/index.html
+++ b/index.html
@@ -18,14 +18,16 @@
         <a href="about.html" class="nav-item nav-about">about↗</a>
         <a href="#" id="scroll-to-footer" class="nav-item nav-contact">contact↗</a>
         <a href="#" class="nav-item nav-menu" id="open-menu">
-          <img src="svg/menu2.svg" class="menu-dark" alt="Menu">
-          <img src="svg/menu.svg.svg" class="menu-light" alt="Menu">
+          <img src="svg/menu2.svg" class="menu-dark menu-icon" alt="Menu">
+          <img src="svg/menu.svg.svg" class="menu-light menu-icon" alt="Menu">
+          <img src="svg/close.svg" class="close-dark menu-icon" alt="Close">
+          <img src="svg/close2.svg" class="close-light menu-icon" alt="Close">
         </a>
       </nav>
       <div id="mobile-menu" class="mobile-menu-overlay">
-        <a href="index.html">home</a>
-        <a href="about.html">about</a>
-        <a href="contact.html">contact</a>
+        <a href="index.html">home↗</a>
+        <a href="about.html">about↗</a>
+        <a href="contact.html">contact↗</a>
       </div>
     </section>
 

--- a/project_djavu.html
+++ b/project_djavu.html
@@ -18,14 +18,16 @@
         <a href="about.html" class="nav-item nav-about">about↗</a>
         <a href="contact.html" class="nav-item nav-contact">contact↗</a>
         <a href="#" class="nav-item nav-menu" id="open-menu">
-          <img src="svg/menu2.svg" class="menu-dark" alt="Menu">
-          <img src="svg/menu.svg.svg" class="menu-light" alt="Menu">
+          <img src="svg/menu2.svg" class="menu-dark menu-icon" alt="Menu">
+          <img src="svg/menu.svg.svg" class="menu-light menu-icon" alt="Menu">
+          <img src="svg/close.svg" class="close-dark menu-icon" alt="Close">
+          <img src="svg/close2.svg" class="close-light menu-icon" alt="Close">
         </a>
       </nav>
       <div id="mobile-menu" class="mobile-menu-overlay">
-        <a href="index.html">home</a>
-        <a href="about.html">about</a>
-        <a href="contact.html">contact</a>
+        <a href="index.html">home↗</a>
+        <a href="about.html">about↗</a>
+        <a href="contact.html">contact↗</a>
       </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -160,8 +160,12 @@ window.addEventListener('DOMContentLoaded', () => {
   openMenuBtn?.addEventListener('click', e => {
     e.preventDefault();
     mobileMenu?.classList.toggle('open');
+    openMenuBtn.classList.toggle('open');
   });
   mobileMenu?.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => mobileMenu.classList.remove('open'));
+    link.addEventListener('click', () => {
+      mobileMenu.classList.remove('open');
+      openMenuBtn.classList.remove('open');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- update menu overlay markup to include open/close icons
- style overlay background for light and dark themes
- toggle menu icon when opening/closing overlay
- ensure contact footer fills the entire viewport
- hide footer hand icon on small screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ab8b160c083209f69adb7a0f49f3f