### PR TITLE
Disable scroll on mobile menu

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -38,6 +38,9 @@ html {
   height: 100%;
   scroll-behavior: auto; /* Enable native smooth scrolling */
 }
+html.no-scroll {
+  overflow: hidden;
+}
 *, *::before, *::after {
   box-sizing: inherit;
   margin: 0;

--- a/script.js
+++ b/script.js
@@ -157,15 +157,32 @@ window.addEventListener('DOMContentLoaded', () => {
   // Mobile menu toggle
   const mobileMenu = document.getElementById('mobile-menu');
   const openMenuBtn = document.getElementById('open-menu');
+  const htmlEl = document.documentElement;
   openMenuBtn?.addEventListener('click', e => {
     e.preventDefault();
-    mobileMenu?.classList.toggle('open');
+    const isOpen = mobileMenu?.classList.toggle('open');
     openMenuBtn.classList.toggle('open');
+    if (isOpen) {
+      scroll.stop();
+      htmlEl.classList.add('no-scroll');
+    } else {
+      scroll.start();
+      htmlEl.classList.remove('no-scroll');
+    }
   });
+
+  function closeMenu() {
+    if (!mobileMenu.classList.contains('open')) return;
+    mobileMenu.classList.remove('open');
+    openMenuBtn.classList.remove('open');
+    scroll.start();
+    htmlEl.classList.remove('no-scroll');
+  }
+
   mobileMenu?.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
-      mobileMenu.classList.remove('open');
-      openMenuBtn.classList.remove('open');
-    });
+    link.addEventListener('click', closeMenu);
+  });
+  document.querySelectorAll('.navbar a:not(#open-menu)').forEach(link => {
+    link.addEventListener('click', closeMenu);
   });
 });


### PR DESCRIPTION
## Summary
- prevent page scrolling when mobile menu is open
- close mobile menu on navbar link click

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_688af2b2d7ec83208481776fb84accf6