### PR TITLE
Add page wipe for about and contact

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/locomotive-scroll@4.1.4/dist/locomotive-scroll.min.css" />
 </head>
 <body class="dark">
+  <div class="page-wipe"></div>
   <main data-scroll-container>
     <section data-scroll-section>
       <nav class="navbar">

--- a/contact.html
+++ b/contact.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/locomotive-scroll@4.1.4/dist/locomotive-scroll.min.css" />
 </head>
 <body class="dark contact-page">
+  <div class="page-wipe"></div>
   <main data-scroll-container>
     <section data-scroll-section>
       <nav class="navbar">

--- a/css/base.css
+++ b/css/base.css
@@ -77,3 +77,18 @@ a:visited {
 [data-scroll-section] {
   position: relative;
 }
+
+/* === PAGE WIPE REVEAL === */
+.page-wipe {
+  position: fixed;
+  inset: 0;
+  background: #000; /* Match dark page background */
+  z-index: 1000;
+  pointer-events: none;
+  animation: page-wipe 1s ease forwards;
+}
+
+@keyframes page-wipe {
+  from { transform: translateX(0); }
+  to { transform: translateX(100%); }
+}

--- a/script.js
+++ b/script.js
@@ -24,11 +24,17 @@ window.addEventListener('DOMContentLoaded', () => {
   const talkFooter          = document.querySelector('.contact-block .talk-footer');
   const contactText         = document.querySelector('.contact-block .footer-contact-text');
   const handFooter          = document.querySelector('.contact-block .hand-footer');
+  const pageWipe            = document.querySelector('.page-wipe');
 
   const SNAP_SETTINGS = {
     duration: 500,
     easing: [0.25, 0, 0.35, 1],
   };
+
+  // Remove page wipe overlay once the animation completes
+  if (pageWipe) {
+    pageWipe.addEventListener('animationend', () => pageWipe.remove());
+  }
 
   let isManuallyScrollingToFooter = false;
 


### PR DESCRIPTION
## Summary
- add `<div class="page-wipe"></div>` overlay to about and contact pages
- define page wipe animation in CSS and remove overlay via JS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b0528e2e083209cea7d1b12350524