### PR TITLE
Add fade-in effect to project details images

### DIFF
--- a/css/project-details.css
+++ b/css/project-details.css
@@ -76,6 +76,14 @@
   width: 100%;
   height: auto;
   display: block;
+  opacity: 0;
+  transform: translateY(40px) skewY(3deg);
+  transition: opacity 0.8s ease-out, transform 0.8s ease-out;
+}
+
+.project-details img.reveal {
+  opacity: 1;
+  transform: translateY(0) skewY(0);
 }
 
 .project-details .main-image {

--- a/script.js
+++ b/script.js
@@ -85,6 +85,12 @@ window.addEventListener('DOMContentLoaded', () => {
     tile.setAttribute('data-scroll-class', 'reveal');
   });
 
+  // Project detail images animation class
+  document.querySelectorAll('.project-details img').forEach(img => {
+    img.setAttribute('data-scroll', '');
+    img.setAttribute('data-scroll-class', 'reveal');
+  });
+
   // Wipe reveal animation for hero SVGs
   document.querySelectorAll('.hero .svg-container.text, .hero .svg-container.hand, .hero .svg-container.pc').forEach((container, i) => {
     if (!container.querySelector('.wipe-reveal')) {


### PR DESCRIPTION
## Summary
- add scroll-triggered reveal for images on the project details page
- wire up Locomotive Scroll in `script.js` for project images

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b081ed5e483209d4159b765f03f51