### PR TITLE
Fix project tile reveal on load

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,6 +92,12 @@ window.addEventListener('load', () => {
     img.setAttribute('data-scroll-class', 'reveal');
   });
 
+  // Ensure Locomotive Scroll recalculates positions after images are loaded
+  // so project tiles immediately gain the reveal class without requiring
+  // a manual window resize.
+  setTimeout(() => scroll.update(), 0);
+  window.addEventListener('resize', () => scroll.update());
+
   // Wipe reveal animation for hero SVGs
   document.querySelectorAll('.hero .svg-container.text, .hero .svg-container.hand, .hero .svg-container.pc').forEach((container, i) => {
     if (!container.querySelector('.wipe-reveal')) {


### PR DESCRIPTION
## Summary
- ensure LocomotiveScroll recalculates after images load
- update scrolling on window resize

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688cb386a5a483208553028e5144e682